### PR TITLE
A: https://www.expressen.se/

### DIFF
--- a/scandinavianlist/scandinavianlist_specific_block.txt
+++ b/scandinavianlist/scandinavianlist_specific_block.txt
@@ -1,1 +1,2 @@
 ||d9v72urx9pbbc.cloudfront.net^
+||c.cdn-expressen.se/images/c9/f6/c9f6deb7fd7846529c4af3edd68f94d2/640@60.jpg

--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -1,3 +1,6 @@
 gp.se##.ml-adon-hide-box
 expressen.se##.discount-ad
+expressen.se##.html-widget
+expressen.se#?#.teaser:-abp-has(> .vignette--image > canvas[width="640"])
 dn.se##.sponsored-teaser
+expressen.se#?#.teaser:-abp-has(> .vignette--text:-abp-contains(NOA Gallery))

--- a/scandinavianlist/scandinavianlist_thirdparty.txt
+++ b/scandinavianlist/scandinavianlist_thirdparty.txt
@@ -1,0 +1,1 @@
+||happygreen.se/media/iframe/$subdocument,third-party


### PR DESCRIPTION
Hiding the "ANNONS Låna pengar" and "NOA Gallery" ad was not easy to find something to target.

This might need some extra checking, I am not sure the NOA Gallery filters will be usefull for very long, but I couldn't come up with anything generic for that box that wouldn't cause false positives on the site. 
I made a special note on this site to check it often.