### PR TITLE
A: https://www.allabolag.se/

### DIFF
--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -9,3 +9,4 @@ dn.se##.sponsored-teaser
 expressen.se#?#.teaser:-abp-has(> .vignette--text:-abp-contains(NOA Gallery))
 di.se#?#.di_section-heading:-abp-contains(Plånbokskoll)
 di.se##.di_panorama__isAdLabel
+allabolag.se#?#li,article:-abp-has(.advert__mark)


### PR DESCRIPTION
They are mixing promoted external content and links to there own in-house services in ad spaces.
Fortunately all ads and promoted content seems to be marked with this tag.

This will also remove articles extracts from https://www.allabolag.se/affarskoll/kategori/ekonomi-finans that are maked as advertisment (Annons), but I think that is right.