### PR TITLE
A: https://www.nyteknik.se/

### DIFF
--- a/scandinavianlist/scandinavianlist_adservers.txt
+++ b/scandinavianlist/scandinavianlist_adservers.txt
@@ -1,1 +1,2 @@
 ||uptobranding.com^$third-party
+||hmads.se^$third-party

--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -17,3 +17,6 @@ familjeliv.se##.adtoma_container
 familjeliv.se##.ad_right
 metro.se#?#.c-teaser:-abp-has(> .m-teaser__body > .o-label--ad)
 metro.se##.o-preview--ad
+nyteknik.se##.ad-teaser
+nyteknik.se##.ad-teaser-flash
+


### PR DESCRIPTION
hmads.se is owned by Admoove\Hi-Media digital markering company and empty when accessing directly so I think this adserver block is pretty safe.

Loading of other ads is integrated into the lazy loading script of the site and content delivered from same sources so hiding it.