### PR TITLE
A: https://helagotland.se/start/

### DIFF
--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -71,6 +71,6 @@ spelo.se##div[id^="banner"]
 elevspel.se##.rek-unit
 ekuriren.se###bostad
 ekuriren.se###lokusmotor
-ekuriren.se##iframe[id^=lystra]
 vetgirig.nu###ads
 hastnet.se##.add-wrap
+unt.se,corren.se,nsd.se,nt.se,helagotland.se,ekuriren.se###sf + section

--- a/scandinavianlist/scandinavianlist_thirdparty.txt
+++ b/scandinavianlist/scandinavianlist_thirdparty.txt
@@ -10,3 +10,4 @@
 ||breakit.solidtango.com^$subdocument,third-party
 ||qx.se^$image,third-party,domain=qruiser.com
 ||custosgroup.com^$subdocument,third-party
+||cdn2.lystra.se/pages/*/BIO*$subdocument,third-party


### PR DESCRIPTION
Improved Cinema ads filter. See nt.se branch for images of the ad and code

This will prevent loading the cinema add widget used by all these newspapers as well as collapse the white-space