### PR TITLE
A: http://lantbruksnet.se/

### DIFF
--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -89,3 +89,5 @@ folkbladet.nu##.vkmui-ContainerBase > .vkmui-FlexVerticalCentered
 elektronikforumet.com##a[href$="donate.php"] ~ a
 elektronikforumet.com##td > a[href^="https://elektronikforumet.com/images/www/delivery/ck.php"]
 hamsterpaj.net###sidebar_wrapper > .zone
+lantbruksnet.se###topreklam
+lantbruksnet.se###banner_right


### PR DESCRIPTION
One of the hidden ad slots is used for an internal ad to sell ads. I am guessing it is just temporary to fill unsold space and there are other links to there ad prices site so it might be ok to hide?