### PR TITLE
A: https://www.budstikka.no/

### DIFF
--- a/scandinavianlist/scandinavianlist_adservers.txt
+++ b/scandinavianlist/scandinavianlist_adservers.txt
@@ -1,3 +1,4 @@
 ||uptobranding.com^$third-party
 ||hmads.se^$third-party
 ||delivery.adten.eu^$xmlhttprequest,third-party
+||track.adform.net^$subdocument,third-party

--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -97,3 +97,5 @@ hamsterpaj.net###sidebar_wrapper > .zone
 lantbruksnet.se###topreklam
 lantbruksnet.se###banner_right
 sn.se##[id^="lystra_"]
+budstikka.no##bazaar-ad
+budstikka.no##.lokalnative


### PR DESCRIPTION
track.adform.net delivers the ad in the lokalnative element. It seems to be an ad server delivering content and not just tracking. I added subdocument to be on the safe side after reading an issue that blocking track.adform.net breaks links from prisjakt (price comparison site), even though I think the issue only relates to system wide ad blocking and the android app from prisjakt.