### PR TITLE
Altaposten.no

### DIFF
--- a/scandinavianlist/scandinavianlist_whitelist.txt
+++ b/scandinavianlist/scandinavianlist_whitelist.txt
@@ -1,2 +1,3 @@
 @@||cdn.easy-ads.com/js/swipemod.js^$script,domain=oa.no|rb.no|ta.no|sb.no
 @@||easy-ads.com/subscriber^$image,domain=oa.no|rb.no|ta.no|sb.no
+@@||stillingledig.*.no/jobs/api/ads^$xmlhttprequest,domain=altaposten.no

--- a/scandinavianlist/scandinavianlist_whitelist.txt
+++ b/scandinavianlist/scandinavianlist_whitelist.txt
@@ -1,3 +1,3 @@
 @@||cdn.easy-ads.com/js/swipemod.js^$script,domain=oa.no|rb.no|ta.no|sb.no
 @@||easy-ads.com/subscriber^$image,domain=oa.no|rb.no|ta.no|sb.no
-@@||stillingledig.*.no/jobs/api/ads^$xmlhttprequest,domain=altaposten.no
+@@||stillingledig.*.no/jobs/api/ads^$xmlhttprequest


### PR DESCRIPTION
I think it would be maybe ok to remove the domain filter from this whitelist rule as in the second commit. It is fairly specific anyway. stillingledig sould mean job vacancies and then it has jobs once more in the url. So it would probably be safe to always exclude from the /api/ads rule