### PR TITLE
A: https://www.flashscore.dk/

### DIFF
--- a/scandinavianlist/scandinavianlist_specific_hide.txt
+++ b/scandinavianlist/scandinavianlist_specific_hide.txt
@@ -124,3 +124,5 @@ purehelp.no###monetary_block_1
 purehelp.no###clientLinkArea3
 purehelp.no##.dfptop
 agderposten.no##div[data-adtext="Annonse"]
+flashscore.dk##[id^="box_over_content"]
+flashscore.dk##.container__bannerZone


### PR DESCRIPTION
the box over content rule is to match booth the top banner on the main page and the bottom banner in the match pop-ups.

I left the bet365 ad that is under the section that show the live odds but removed the generic banners.